### PR TITLE
CDA xslt problem solved

### DIFF
--- a/oec2Interface/src/main/java/ke/go/moh/oec/pisinterfaces/controller/CdaInterfaceController.java
+++ b/oec2Interface/src/main/java/ke/go/moh/oec/pisinterfaces/controller/CdaInterfaceController.java
@@ -28,11 +28,10 @@ import org.springframework.web.bind.annotation.*;
  *
  * The controller that controls all requests used by this interface.
  *
- * In order to handle ReSTful URLs (such as "/viewCda/{cdaID}"), it is necessary
- * to serve from a non-root context. See the web.xml file for path info.
  *
  */
 @Controller
+@RequestMapping("/*.htm")
 @SessionAttributes({"patientId", "cdaList"})
 public class CdaInterfaceController {
 
@@ -47,7 +46,7 @@ public class CdaInterfaceController {
      * @param model
      * @return String naming the .jsp page to display
      */
-    @RequestMapping(value = "/sentPatientId", method = RequestMethod.GET)
+    @RequestMapping(value = "/sentPatientId.htm", method = RequestMethod.GET)
     public String showUserForm(ModelMap model) {
         PatientIdentification patientId = new PatientIdentification();
         model.addAttribute(patientId);
@@ -63,7 +62,7 @@ public class CdaInterfaceController {
      * @param patientId
      * @return String naming the .jsp page to display
      */
-    @RequestMapping(value = "/sentPatientId", method = RequestMethod.POST)
+    @RequestMapping(value = "/sentPatientId.htm", method = RequestMethod.POST)
     public String onSubmit(
             @ModelAttribute("patientIdentification") PatientIdentification patientId,
             ModelMap model) throws SiteException {
@@ -77,7 +76,7 @@ public class CdaInterfaceController {
             // Store matching CDA docs in session
             model.addAttribute("cdaList", resultList);
         }
-        return "redirect:sendSuccess";
+        return "redirect:sendSuccess.htm";
     }
 
     /**
@@ -88,7 +87,7 @@ public class CdaInterfaceController {
      * @param model
      * @return String naming the .jsp page to display
      */
-    @RequestMapping(value = "/sendSuccess", method = RequestMethod.GET)
+    @RequestMapping(value = "/sendSuccess.htm", method = RequestMethod.GET)
     public String sendSuccess(
             @ModelAttribute("cdaList") Map<String, CdaRecord> cdaList,
             ModelMap model) {
@@ -103,7 +102,7 @@ public class CdaInterfaceController {
     }
 
     /**
-     * ReSTful view controller to display a single CDA. Looks first to the
+     * View controller to display a single CDA. Looks first to the
      * session for the requested cdaID, making a round trip to the external
      * query service only when necessary.
      *
@@ -111,9 +110,9 @@ public class CdaInterfaceController {
      * @param model
      * @return String naming the .jsp page to display
      */
-    @RequestMapping(value = "/viewCda/{cdaID}", method = RequestMethod.GET)
+    @RequestMapping(value = "/viewCda.htm", method = RequestMethod.GET)
     public String viewCda(
-            @PathVariable String cdaID,
+            @RequestParam String cdaID,
             @ModelAttribute("cdaList") Map<String, CdaRecord> cdaList,
             ModelMap model) throws SiteException {
         // Check the session for the requested cda
@@ -132,7 +131,7 @@ public class CdaInterfaceController {
                 String[] errors = new String[1];
                 errors[0] = "No Match Found";
                 model.addAttribute("errors", errors);
-                return "viewCda";
+                return "sendSuccess";
             }
         }
         String cda = this.addStyleSheet(new StringBuffer(record.getCDA()));

--- a/oec2Interface/src/main/webapp/WEB-INF/jsp/sendSuccess.jsp
+++ b/oec2Interface/src/main/webapp/WEB-INF/jsp/sendSuccess.jsp
@@ -9,11 +9,11 @@
 </head>
 <body>
     <c:if test="${not empty errors}">${errors[0]}</c:if>
-    <p><a href="sentPatientId">New search</a></p>
+    <p><a href="sentPatientId.htm">New search</a></p>
     <ul>
         <c:forEach var="cda" items="${cdaList}">
             <li>
-                <a href="viewCda/${cda.key}">
+                <a href="viewCda.htm?cdaID=${cda.key}">
                     <c:choose>
                         <c:when test="${not empty cda.value.hdssId}">
                             ${cda.value.hdssId}

--- a/oec2Interface/src/main/webapp/WEB-INF/jsp/viewCda.jsp
+++ b/oec2Interface/src/main/webapp/WEB-INF/jsp/viewCda.jsp
@@ -1,3 +1,1 @@
-<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<c:if test="${not empty errors}">${errors[0]}</c:if>
-<c:if test="${not empty params}">${params[0]}</c:if>
+<%@page contentType="text/xml" %>${params[0]}

--- a/oec2Interface/src/main/webapp/WEB-INF/web.xml
+++ b/oec2Interface/src/main/webapp/WEB-INF/web.xml
@@ -16,6 +16,6 @@
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>dispatcher</servlet-name>
-		<url-pattern>/cda/*</url-pattern>
+		<url-pattern>*.htm</url-pattern>
 	</servlet-mapping>
 </web-app>

--- a/oec2Interface/src/main/webapp/index.jsp
+++ b/oec2Interface/src/main/webapp/index.jsp
@@ -1,2 +1,2 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"%>
-<% response.sendRedirect("cda/sentPatientId"); %>
+<% response.sendRedirect("sentPatientId.htm"); %>


### PR DESCRIPTION
Could not find a way to deliver the style sheet using the wildcard
url-pattern, previously selected to create a ReSTful interface.

Reverted to using a common suffix (.htm) in the url-pattern.  Most changes
simply revert to naming all requests *.htm

NB - this means the context created in the request (/cda) is also gone.
Bookmarked URLs are likely wrong - remove the /cda and end with .htm
