### PR TITLE
Update to HTTP receive Mirth channels for ADT and C-PAD companions...

### DIFF
--- a/adt_companion/mirth/adt-companion-receive-via-http.xml
+++ b/adt_companion/mirth/adt-companion-receive-via-http.xml
@@ -5,10 +5,10 @@
   <enabled>true</enabled>
   <version>2.1.1.5490</version>
   <lastModified>
-    <time>1335553892800</time>
+    <time>1337624217783</time>
     <timezone>America/Los_Angeles</timezone>
   </lastModified>
-  <revision>6</revision>
+  <revision>12</revision>
   <sourceConnector>
     <name>sourceConnector</name>
     <properties>
@@ -77,7 +77,13 @@
 //channelMap.put(&apos;filedata&apos;, parts.cpad_csv_export.value);
 
 var decoded = FileUtil.decode(msg[&apos;Content&apos;].toString());
-channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded));</script>
+var decoded2 = &quot;&quot;;
+if (Packages.java.lang.String(decoded).substring(0, 70).match(/[a-zA-Z0-9\+\/]{70}/) != null) {
+  decoded2 = FileUtil.decode(Packages.java.lang.String(decoded));
+} else {
+  decoded2 = decoded;
+}
+channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded2));</script>
             <type>JavaScript</type>
             <data class="map">
               <entry>
@@ -93,7 +99,13 @@ channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded));</scrip
 //channelMap.put(&apos;filedata&apos;, parts.cpad_csv_export.value);
 
 var decoded = FileUtil.decode(msg[&apos;Content&apos;].toString());
-channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded));</string>
+var decoded2 = &quot;&quot;;
+if (Packages.java.lang.String(decoded).substring(0, 70).match(/[a-zA-Z0-9\+\/]{70}/) != null) {
+  decoded2 = FileUtil.decode(Packages.java.lang.String(decoded));
+} else {
+  decoded2 = decoded;
+}
+channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded2));</string>
               </entry>
             </data>
           </step>

--- a/cpad_companion/mirth/cpad-companion-receive-via-http.xml
+++ b/cpad_companion/mirth/cpad-companion-receive-via-http.xml
@@ -5,10 +5,10 @@
   <enabled>true</enabled>
   <version>2.1.1.5490</version>
   <lastModified>
-    <time>1334038321796</time>
+    <time>1337624206830</time>
     <timezone>America/Los_Angeles</timezone>
   </lastModified>
-  <revision>1</revision>
+  <revision>20</revision>
   <sourceConnector>
     <name>sourceConnector</name>
     <properties>
@@ -51,7 +51,7 @@
         <property name="charsetEncoding">DEFAULT_ENCODING</property>
         <property name="host">/opt/mirth/current/appdata/cpad-incoming</property>
         <property name="outputAppend">0</property>
-        <property name="outputPattern">CPAD_export_${date.get(&apos;yyyyMMddHHmmss&apos;)}.csv</property>
+        <property name="outputPattern">CPAD_export_${date.get(&apos;yyyyMMddHHmmssSSS&apos;)}.csv</property>
         <property name="passive">1</property>
         <property name="password">anonymous</property>
         <property name="scheme">file</property>
@@ -77,7 +77,13 @@
 //channelMap.put(&apos;filedata&apos;, parts.cpad_csv_export.value);
 
 var decoded = FileUtil.decode(msg[&apos;Content&apos;].toString());
-channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded));</script>
+var decoded2 = &quot;&quot;;
+if (Packages.java.lang.String(decoded).substring(0, 70).match(/[a-zA-Z0-9\+\/]{70}/) != null) {
+  decoded2 = FileUtil.decode(Packages.java.lang.String(decoded));
+} else {
+  decoded2 = decoded;
+}
+channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded2));</script>
             <type>JavaScript</type>
             <data class="map">
               <entry>
@@ -93,7 +99,13 @@ channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded));</scrip
 //channelMap.put(&apos;filedata&apos;, parts.cpad_csv_export.value);
 
 var decoded = FileUtil.decode(msg[&apos;Content&apos;].toString());
-channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded));</string>
+var decoded2 = &quot;&quot;;
+if (Packages.java.lang.String(decoded).substring(0, 70).match(/[a-zA-Z0-9\+\/]{70}/) != null) {
+  decoded2 = FileUtil.decode(Packages.java.lang.String(decoded));
+} else {
+  decoded2 = decoded;
+}
+channelMap.put(&apos;filedata&apos;, Packages.java.lang.String(decoded2));</string>
               </entry>
             </data>
           </step>


### PR DESCRIPTION
Update the HTTP receive channels so that they will properly handle the base 64 decoding of incoming messages for (hopefully) any version of Mirth between 2.1.1 and 2.2.1.
